### PR TITLE
meta_hours

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,14 @@ We are passionate about supporting artists, whether it's by providing them a gra
   - You can become a steward or ambassador -- help us on various non-technical tackling issues like helping around in our 
   [Discord server](https://discord.gg/kodadot), [translating documentation](/incentives/translating-kodadot.md), or [reporting bugs](contests-programs.md#bug-bounty-program).
   - Another way to contribute would be to publish articles for us! We document and publish KodaDot's recent developments on our [Medium](writings.md).
-  - Participate in [various contests](contests-programs.md). In past we had a contest for KodaDot's new _Discord logo and Animated Banner. Don't worry, more contests are on the way!
+  - Participate in [various contests](contests-programs.md). In past we had a contest for KodaDot's new _Discord logo and Animated Banner_. Don't worry, more contests are on the way!
 
-## Come say Hi!
-We have bi-weekly meetings with contributors of KodaDot to share each other's progress as well as future goals. Learn more [here](meta-hours.md) and come drop in!
+## Come say Hi at KodaDot's Meta_Hours!
+We have bi-weekly meetings with contributors of KodaDot to share each other's progress as well as future goals in our [Discord sever](https://discord.gg/kodadot).
 
-As of April 3rd, 2022, we are hosting a [Gif-memes contest](contests-programs.md#gif-meme-contest)!
- 
+Is this your first time joining? Feel free to catch up on our [past Meta_Hours](https://github.com/kodadot/nft-gallery/discussions/categories/meta-hours)!
+
  ## Need some help?
-- Here are some [tutorials](tutorial-overview.md)
+Here are some [tutorials](tutorial-overview.md)
 ## Presskit & Logo
-- [KodaDot's icons/logos](./presskit.md)
+[KodaDot's icons/logos](./presskit.md)

--- a/docs/meta-hours.md
+++ b/docs/meta-hours.md
@@ -1,4 +1,4 @@
-# Meta_Hours - bi-weekly digest of development progress 
+# Meta_Hours
 - We are having bi-weekly updates from contributors to the KodaDot, including developers, community and creators to share insights on issues we've done, tackling issues, challenges and generally what's happening speaking on roadmap. 
 - You can find summary of all of them at our [kodadot/nft-gallery/discussions under category Meta_Hours](https://github.com/kodadot/nft-gallery/discussions/categories/meta-hours)
 


### PR DESCRIPTION
Hey! I deleted [Meta_Hours](https://docs.kodadot.xyz/meta-hours.html#recent-meta-hours) because we've already summarized it in the welcome page. It seems too repetitive to have a whole page about it when you can just link people to one source that holds all the Meta_Hours discussions. https://github.com/kodadot/nft-gallery/discussions/categories/meta-hours 