### PR TITLE
combined translating-kodadot.md and language-translations.md

### DIFF
--- a/docs/incentives/translating-kodadot.md
+++ b/docs/incentives/translating-kodadot.md
@@ -1,24 +1,53 @@
 # Translating KodaDot
 
-- We are always moving forward and adding new features, therefore it's important to keep KodaDot up-to-date and have all the translations actual.
+We are always innovating and reiterating, which means we must update our documentation as frequently and accurately as possible in all of KodaDot's available languages. We welcome new translations (i.e in another language) as well as updates to our previously existing translations!
 
-- We are welcoming new languages and updates of current translations
+If you'd like to contribute to KodaDot by translating our documentation in any way, please make sure you understand:
 
-### Contributing
+- **ALL** pull requests and commited changes must align with our [contribution guidelines](https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md).
 
-- If you want to contribute by translating KodaDot, please follow our [contributing policy.](https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md)
+- Each contribution needs at least **TWO native-speaking reviewers in the language of the contribution**, otherwise your pull request won't be approved.
 
-- First time [contributing](https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md)?
+Read through our guide for [first-time contributors](https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md) if you'd like more information. 
 
 
-![languages](/language-translations/languages.png)
+### Ready to Contribute?
+
+We'll show you step-by-step on how to contribute to KodaDot by translating
+
+1) Go to [KodaDot's Github Repository](https://github.com/kodadot/nft-gallery)
+2) Go to the "langDir" folder and open it
+![0](/language-translations/0.png)
+3) Once you're in "nft-gallery/langDir/", go to the right upper corner and click on "Fork" - this is the codebase that you'll be able to make changes in 
+![1](/language-translations/1.png)
+
+**IMPORTANT:**
+The "en.json" file is where the new updates (builds/additions) will be. If you're translating in another lanaguge, make sure what you're translating is up to date with the en.json file. You might come across previously translated parts when accessing your language. All you have to do is take what's translated, compare it with en.json, and translate what wasn't previously in your file. Your other option is to start your translation from scratch. 
+![2](/language-translations/2.png)
+![3](/language-translations/4.png)
+
+4) Click on the "edit" icon to make changes. You can scroll through the file to see what hasn't been translated accurately or what hasn't been updated.
+![4](/language-translations/3.png)
+
+5) When you finish making changes, scroll until you see the "Commit Changes" box.
+- If you're updating a previously existing translation, put "Update yourlanguage.json" (for example, "Update fr.json") 
+- If you're adding a new language, put "Add mylanguage.json" (for example, "Add kr.json")
+
+Then commit all the changes
+
+![5](/language-translations/5.png)
+
+:tada: Congratulations! You've submitted your change! 
+All you have to do is wait for our approval
+
+ ***Remember, you have to get TWO native-speaking reviewers to review your change***
+
+In case you have any questions, don't hesitate and contact us on [discord](https://discord.gg/yzdWuFaY8W)!
 
 ### Rewards
 
-- $ -- update existing language, minor tweaks with significant upgrades, rephrasing etc
-- $$ -- introducing a whole new language
+$50-100 USD - Updating a previously existing translation (minor tweaks, significant upgrades, rephrasing etc.)
+$150-300 USD - Translating a new language
 
 
-### Tutorial
 
-- If you don't see your language and you would like to add it or update current one, have a look on our [tutorial](/tutorials/language-translations.md).


### PR DESCRIPTION
It seems too much to have two files explaining a summary of something and then a tutorial of the same thing. Might as well combine them both!